### PR TITLE
Add created and due dates to notes

### DIFF
--- a/src/lib/components/AddOrUpdateNoteModal.svelte
+++ b/src/lib/components/AddOrUpdateNoteModal.svelte
@@ -1,23 +1,28 @@
 <script lang="ts">
-	import TextInput from './TextInput.svelte';
-	import Button from './Button.svelte';
-	import type { Note } from '$lib/db';
-	import { addNoteToDb } from '$lib/dbDal';
+	import TextInput from "./TextInput.svelte";
+	import Button from "./Button.svelte";
+	import type { Note } from "$lib/db";
+	import { addOrUpdateNote } from "$lib/dbDal";
 
-	export let note: Note | undefined = undefined;
+	export let note: Note = {
+		title: "",
+		content: "",
+		createdDate: new Date(),
+		dueDate: undefined,
+	};
+
 	export let open = false;
 
-	let noteTitle = note?.title ?? '';
-	let noteContent = note?.title ?? '';
 	let success = false;
 
 	async function handleSubmit() {
-		var newNote: Note = {
-			title: noteTitle,
-			content: noteContent
-		};
+		// if the note is already in the db, do not change the created date
+		var createdDate: Date = new Date();
+		if (note?.id && note.createdDate) {
+			createdDate = note.createdDate;
+		}
 
-		success = await addNoteToDb(newNote);
+		success = await addOrUpdateNote(note);
 
 		if (success) {
 			open = false;
@@ -34,12 +39,24 @@
 		<div class="w-full max-w-sm rounded-lg bg-gray-600 p-6 shadow-lg">
 			<div class="mb-4 flex justify-between text-xl font-semibold">
 				<h2 class="">Edit note</h2>
-				<button onclick={() => (open = !open)} class="cursor-pointer">&times;</button>
+				<button onclick={() => (open = !open)} class="cursor-pointer"
+					>&times;</button
+				>
 			</div>
-			<TextInput label="Title" bind:value={noteTitle}></TextInput>
-			<TextInput type="textarea" label="Content" bind:value={noteContent}></TextInput>
-			<!-- Close button -->
-			<div class="flex justify-end">
+			<TextInput label="Title" bind:value={note.title}></TextInput>
+			<TextInput type="textarea" label="Content" bind:value={note.content}
+			></TextInput>
+
+			<div class="flex justify-between">
+				<div class="flex">
+					<input
+						bind:value={note.dueDate}
+						type="date"
+						id="date"
+						class="rounded-lg border border-gray-300 bg-gray-800 text-gray-100 focus:border-transparent focus:ring-2 focus:ring-blue-500 focus:outline-none"
+					/>
+				</div>
+
 				<Button onclick={handleSubmit}>Submit</Button>
 			</div>
 		</div>

--- a/src/lib/components/MiniButton.svelte
+++ b/src/lib/components/MiniButton.svelte
@@ -16,7 +16,8 @@
     {onclick}
     class="hoover:pointer cursor-pointer rounded items-center
     text-center font-bold hover:text-white focus:border-transparent focus:ring-2 focus:ring-white focus:outline-none
-    transition duration-100 bg-transparent text-{color}-500 {classes}
+    transition duration-100 bg-transparent
+    {color == 'red' ? 'text-red-500' : 'text-blue-500'} {classes}
     p-2
     "
     >{@render children()}

--- a/src/lib/components/Nav.svelte
+++ b/src/lib/components/Nav.svelte
@@ -4,7 +4,7 @@
 	export let logoutOnClick = () => {};
 </script>
 
-<nav class="w-screen bg-gray-800 p-4">
+<nav class="bg-gray-800 p-4">
 	<div class="container mx-auto flex items-center justify-between">
 		<div class="flex space-x-4 text-xl" style="max-width: 300px;">
 			<!-- Navbar Items -->

--- a/src/lib/components/NoteCard.svelte
+++ b/src/lib/components/NoteCard.svelte
@@ -52,16 +52,14 @@
 <div id="container{id}" class="rounded bg-gray-600 shadow-md">
 	<div id="header" class="p-4">
 		<div class="flex justify-between">
-			<!-- svelte-ignore a11y_click_events_have_key_events -->
-			<!-- svelte-ignore a11y_no_static_element_interactions -->
-			<div
+			<button
 				onclick={() => (expandTitle = !expandTitle)}
 				class="text-2xl font-bold text-left cursor-pointer {expandTitle
-					? ''
+					? 'break-all'
 					: 'overflow-hidden line-clamp-2'}"
 			>
 				{note?.title ?? "No title available"}
-			</div>
+			</button>
 			<MiniButton color={"red"} onclick={handleDeleteClick}
 				><Trash2 /></MiniButton
 			>
@@ -75,18 +73,16 @@
 			</p>
 		</div>
 	</div>
-	<!-- svelte-ignore a11y_click_events_have_key_events -->
-	<!-- svelte-ignore a11y_no_static_element_interactions -->
-	<div
+	<button
 		id="body"
 		onclick={() => (expandContent = !expandContent)}
 		class="bg-gray-500 p-4 text-left w-full {expandContent
-			? ''
+			? 'break-all'
 			: 'overflow-hidden line-clamp-5'}"
 		style="white-space: pre-wrap;"
 	>
 		{note?.content ?? "No Content"}
-	</div>
+	</button>
 	<div id="footer" class="flex justify-between p-4 h-20">
 		<div id="tags" class="flex">
 			<p>A tag array would go here</p>

--- a/src/lib/components/NoteCard.svelte
+++ b/src/lib/components/NoteCard.svelte
@@ -4,16 +4,17 @@
 	import AddOrUpdateNoteModal from "./AddOrUpdateNoteModal.svelte";
 	import { deleteNote } from "$lib/dbDal";
 	import { Trash2, Pencil } from "lucide-svelte";
-	import { onMount } from "svelte";
 
-	export let note: Note | undefined = undefined;
-	export let id = 0;
+	let { note = $bindable(), id = $bindable(0) } = $props<{
+		note: Note;
+		id: number;
+	}>();
 
-	let expandTitle = false;
-	let expandContent = false;
+	let expandTitle = $state(false);
+	let expandContent = $state(false);
 
-	let dueDateString = "";
-	let createdDateString = "";
+	let dueDateString = $state("");
+	let createdDateString = $state("");
 
 	let handleDeleteClick = async () => {
 		var success = await deleteNote(note);
@@ -24,7 +25,7 @@
 		}
 	};
 
-	onMount(() => {
+	$effect(() => {
 		if (note?.dueDate) {
 			dueDateString =
 				"Due: " +
@@ -46,7 +47,7 @@
 		}
 	});
 
-	let editMode = false;
+	let editMode = $state(false);
 </script>
 
 <div id="container{id}" class="rounded bg-gray-600 shadow-md">
@@ -94,5 +95,11 @@
 </div>
 
 {#if editMode}
-	<AddOrUpdateNoteModal bind:open={editMode} bind:note></AddOrUpdateNoteModal>
+	<AddOrUpdateNoteModal
+		{note}
+		bind:open={editMode}
+		onupdate={(newNote: Note) => {
+			note = newNote;
+		}}
+	></AddOrUpdateNoteModal>
 {/if}

--- a/src/lib/components/NoteCard.svelte
+++ b/src/lib/components/NoteCard.svelte
@@ -4,49 +4,99 @@
 	import AddOrUpdateNoteModal from "./AddOrUpdateNoteModal.svelte";
 	import { deleteNote } from "$lib/dbDal";
 	import { Trash2, Pencil } from "lucide-svelte";
+	import { onMount } from "svelte";
 
 	export let note: Note | undefined = undefined;
+	export let id = 0;
+
+	let expandTitle = false;
+	let expandContent = false;
+
+	let dueDateString = "";
+	let createdDateString = "";
 
 	let handleDeleteClick = async () => {
 		var success = await deleteNote(note);
 		if (success) {
+			return;
+		} else {
+			alert("Failed to delete note");
 		}
 	};
+
+	onMount(() => {
+		if (note?.dueDate) {
+			dueDateString =
+				"Due: " +
+				new Date(note.dueDate).toLocaleDateString("en-US", {
+					month: "numeric",
+					day: "numeric",
+					year: "numeric",
+				});
+		}
+
+		if (note?.createdDate) {
+			createdDateString =
+				"Created: " +
+				note.createdDate.toLocaleDateString("en-US", {
+					month: "numeric",
+					day: "numeric",
+					year: "numeric",
+				});
+		}
+	});
 
 	let editMode = false;
 </script>
 
-{#if true}
-	<div id="container" class="rounded bg-gray-600 shadow-md">
-		<div id="header" class="flex justify-between p-4">
-			<h2 class="text-2xl font-bold text-left">
+<div id="container{id}" class="rounded bg-gray-600 shadow-md">
+	<div id="header" class="p-4">
+		<div class="flex justify-between">
+			<!-- svelte-ignore a11y_click_events_have_key_events -->
+			<!-- svelte-ignore a11y_no_static_element_interactions -->
+			<div
+				onclick={() => (expandTitle = !expandTitle)}
+				class="text-2xl font-bold text-left cursor-pointer {expandTitle
+					? ''
+					: 'overflow-hidden line-clamp-2'}"
+			>
 				{note?.title ?? "No title available"}
-			</h2>
+			</div>
 			<MiniButton color={"red"} onclick={handleDeleteClick}
 				><Trash2 /></MiniButton
 			>
 		</div>
-		<div
-			id="body"
-			class="bg-gray-500 p-4 text-left"
-			style="white-space: pre-wrap;"
-		>
-		{note?.content ?? "No Content"}
-	</div>
-		<div id="footer" class="flex justify-between p-4">
-			<div id="tags" class="flex">
-				<p>A tag array would go here</p>
-			</div>
-			{#if editMode}
-				Doesn't work yet
-			{/if}
-			<MiniButton onclick={() => (editMode = !editMode)}
-				><Pencil /></MiniButton
-			>
+		<div class="flex text-left justify-between pt-3">
+			<p class="text-sm text-gray-200">
+				{createdDateString}
+			</p>
+			<p class="text-sm text-gray-200">
+				{dueDateString}
+			</p>
 		</div>
 	</div>
-{/if}
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div
+		id="body"
+		onclick={() => (expandContent = !expandContent)}
+		class="bg-gray-500 p-4 text-left w-full {expandContent
+			? ''
+			: 'overflow-hidden line-clamp-5'}"
+		style="white-space: pre-wrap;"
+	>
+		{note?.content ?? "No Content"}
+	</div>
+	<div id="footer" class="flex justify-between p-4 h-20">
+		<div id="tags" class="flex">
+			<p>A tag array would go here</p>
+		</div>
+		<MiniButton onclick={() => (editMode = !editMode)}
+			><Pencil /></MiniButton
+		>
+	</div>
+</div>
 
 {#if editMode}
-	<AddOrUpdateNoteModal bind:note></AddOrUpdateNoteModal>
+	<AddOrUpdateNoteModal bind:open={editMode} bind:note></AddOrUpdateNoteModal>
 {/if}

--- a/src/lib/components/NotecardTable.svelte
+++ b/src/lib/components/NotecardTable.svelte
@@ -6,12 +6,12 @@
 </script>
 
 <div class="flex flex-col lg:flex-row lg:flex-wrap md:flex-row md:flex-wrap">
-    {#each notes as note, index}
+    {#each notes as note, index (note)}
         <div
             class="lg:w-1/3 sm:w-full md:w-1/2 p-4"
             style="flex-grow-1 flex-basis: auto;"
         >
-            <Notecard id={index} bind:note></Notecard>
+            <Notecard bind:note id={index}></Notecard>
         </div>
     {/each}
 </div>

--- a/src/lib/components/NotecardTable.svelte
+++ b/src/lib/components/NotecardTable.svelte
@@ -5,8 +5,13 @@
     export let notes: Note[] = [];
 </script>
 
-<div class="grid grid-cols-1 sm:grid-cols-2 gap-4 lg:grid-cols-3">
-    {#each notes as note}
-        <Notecard bind:note></Notecard>
+<div class="flex flex-col lg:flex-row lg:flex-wrap md:flex-row md:flex-wrap">
+    {#each notes as note, index}
+        <div
+            class="lg:w-1/3 sm:w-full md:w-1/2 p-4"
+            style="flex-grow-1 flex-basis: auto;"
+        >
+            <Notecard id={index} bind:note></Notecard>
+        </div>
     {/each}
 </div>

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -11,10 +11,10 @@ export interface Tag {
 
 export interface Note {
     id?: number;
-    title: string | undefined;
-    content: string | undefined;
-    dueDate: Date | undefined;
-    createdDate: Date | undefined;
+    title?: string;
+    content?: string;
+    dueDate?: Date;
+    createdDate?: Date;
 }
 
 export class MyAppDatabase extends Dexie {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -13,6 +13,8 @@ export interface Note {
     id?: number;
     title: string | undefined;
     content: string | undefined;
+    dueDate: Date | undefined;
+    createdDate: Date | undefined;
 }
 
 export class MyAppDatabase extends Dexie {
@@ -22,7 +24,7 @@ export class MyAppDatabase extends Dexie {
     constructor() {
         super('myAppDatabase');
         this.version(1).stores({
-            notes: '++id, title, content', // primary key and indexed properties
+            notes: '++id, title, content, dueDate, createdDate', // primary key and indexed properties
             tags: '++id, name, color, noteId'
         });
         this.notes = this.table('notes');

--- a/src/lib/dbDal.ts
+++ b/src/lib/dbDal.ts
@@ -2,10 +2,15 @@ import Dexie from "dexie";
 import { db } from "$lib/db";
 import type { Note, Tag } from "$lib/db";
 
-export async function addNoteToDb(note: Note, tags: Tag[] = []): Promise<boolean> {
+export async function addOrUpdateNote(note: Note, tags: Tag[] = []): Promise<boolean> {
     try {
-        await db.notes.add(note)
-        await db.tags.bulkAdd(tags);
+        if (note.id) {
+            await db.notes.update(note.id, note);
+            await db.tags.bulkAdd(tags);
+        } else {
+            await db.notes.add(note);
+            await db.tags.bulkAdd(tags);
+        }
         return true;
     } catch (error) {
         console.log(error);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -7,7 +7,7 @@
 
 <div class="min-h-screen bg-gray-700 text-white flex flex-col">
 	<Nav />
-	<div class="flex flex-grow justify-center">
+	<div class="flex flex-grow justify-center mx-3">
 		{@render children()}
 	</div>
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -105,13 +105,24 @@
 		{#if showMoreFilters}
 			<div class="flex justify-between">
 				<div class="mx-1">
-					<label for="filterCreatedStartDate" class="text-left block"
+					<label for="filterDueStartDate" class="text-left block"
 						>Due From Date:</label
 					>
 					<input
-						bind:value={filterDueStartDate}
+						oninput={(e) => {
+							filterDueStartDate = new Date();
+							const tempDate = e.currentTarget.value.split("-");
+							filterDueStartDate.setFullYear(
+								parseInt(tempDate[0]),
+							);
+							filterDueStartDate.setMonth(
+								parseInt(tempDate[1]) - 1,
+							);
+							filterDueStartDate.setDate(parseInt(tempDate[2]));
+						}}
+						value={filterDueStartDate?.toISOString().split("T")[0]}
 						type="date"
-						id="filterCreatedStartDate"
+						id="filterDueStartDate"
 						class="rounded-lg border border-gray-300 bg-gray-800 text-gray-100 focus:border-transparent focus:ring-2 focus:ring-blue-500 focus:outline-none"
 					/>
 				</div>
@@ -120,9 +131,18 @@
 						>To Date:</label
 					>
 					<input
-						bind:value={filterDueEndDate}
+						oninput={(e) => {
+							filterDueEndDate = new Date();
+							const tempDate = e.currentTarget.value.split("-");
+							filterDueEndDate.setFullYear(parseInt(tempDate[0]));
+							filterDueEndDate.setMonth(
+								parseInt(tempDate[1]) - 1,
+							);
+							filterDueEndDate.setDate(parseInt(tempDate[2]));
+						}}
+						value={filterDueEndDate?.toISOString().split("T")[0]}
 						type="date"
-						id="filterCreatedEndDate"
+						id="filterDueEndDate"
 						class="rounded-lg border border-gray-300 bg-gray-800 text-gray-100 focus:border-transparent focus:ring-2 focus:ring-blue-500 focus:outline-none"
 					/>
 				</div>
@@ -132,7 +152,22 @@
 						>Created From Date:</label
 					>
 					<input
-						bind:value={filterCreatedStartDate}
+						oninput={(e) => {
+							filterCreatedStartDate = new Date();
+							const tempDate = e.currentTarget.value.split("-");
+							filterCreatedStartDate.setFullYear(
+								parseInt(tempDate[0]),
+							);
+							filterCreatedStartDate.setMonth(
+								parseInt(tempDate[1]) - 1,
+							);
+							filterCreatedStartDate.setDate(
+								parseInt(tempDate[2]),
+							);
+						}}
+						value={filterCreatedStartDate
+							?.toISOString()
+							.split("T")[0]}
 						type="date"
 						id="filterCreatedStartDate"
 						class="rounded-lg border border-gray-300 bg-gray-800 text-gray-100 focus:border-transparent focus:ring-2 focus:ring-blue-500 focus:outline-none"
@@ -143,7 +178,20 @@
 						>To Date:</label
 					>
 					<input
-						bind:value={filterCreatedEndDate}
+						oninput={(e) => {
+							filterCreatedEndDate = new Date();
+							const tempDate = e.currentTarget.value.split("-");
+							filterCreatedEndDate.setFullYear(
+								parseInt(tempDate[0]),
+							);
+							filterCreatedEndDate.setMonth(
+								parseInt(tempDate[1]) - 1,
+							);
+							filterCreatedEndDate.setDate(parseInt(tempDate[2]));
+						}}
+						value={filterCreatedEndDate
+							?.toISOString()
+							.split("T")[0]}
 						type="date"
 						id="filterCreatedEndDate"
 						class="rounded-lg border border-gray-300 bg-gray-800 text-gray-100 focus:border-transparent focus:ring-2 focus:ring-blue-500 focus:outline-none"

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,24 +5,84 @@
 	import AddOrUpdateNoteModal from "$lib/components/AddOrUpdateNoteModal.svelte";
 	import { liveQuery, type Observable } from "dexie";
 	import type { Note } from "$lib/db";
+	import { FunnelX } from "lucide-svelte";
+	import MiniButton from "$lib/components/MiniButton.svelte";
 
 	let addNoteModal = $state(false);
 	let searchTerm = $state("");
+
+	let filterCreatedStartDate: Date | undefined = $state(undefined);
+	let filterCreatedEndDate: Date | undefined = $state(undefined);
+
+	let filterDueStartDate: Date | undefined = $state(undefined);
+	let filterDueEndDate: Date | undefined = $state(undefined);
+
+	let showMoreFilters = $state(true);
+
 	let dbNotes: Observable<Note[]> = liveQuery(() =>
 		db.notes.limit(100).toArray(),
 	);
 	let displayedNotes: Note[] = $state([]);
 
+	let clearFilters = () => {
+		filterCreatedStartDate = undefined;
+		filterCreatedEndDate = undefined;
+		filterDueStartDate = undefined;
+		filterDueEndDate = undefined;
+		searchTerm = "";
+	};
+
 	$effect(() => {
-		displayedNotes = $dbNotes?.filter((note) => {
-			if (searchTerm == "") {
-				return true;
-			}
-			if (!note.title) {
-				return false;
-			}
-			return note.title.toLowerCase().includes(searchTerm.toLowerCase());
-		});
+		displayedNotes = $dbNotes
+			?.filter((note) => {
+				if (!note.title) {
+					return false;
+				}
+
+				// default date selection is not good, so we need to convert the output to real date objects
+				const createdDate = note.createdDate
+					? new Date(note.createdDate)
+					: null;
+				const createdStartDate = filterCreatedStartDate
+					? new Date(filterCreatedStartDate)
+					: null;
+				const createdEndDate = filterCreatedEndDate
+					? new Date(filterCreatedEndDate)
+					: null;
+
+				const dueDate = note.dueDate ? new Date(note.dueDate) : null;
+				const dueStartDate = filterDueStartDate
+					? new Date(filterDueStartDate)
+					: null;
+				const dueEndDate = filterDueEndDate
+					? new Date(filterDueEndDate)
+					: null;
+
+				// if there's an end date, we want the entire day to be inclusive
+				if (createdEndDate) {
+					createdEndDate.setHours(23, 59, 59, 999); // Set to 11:59:59 PM
+				}
+				if (dueEndDate) {
+					dueEndDate.setHours(23, 59, 59, 999); // Set to 11:59:59 PM
+				}
+
+				return (
+					note.title
+						.toLowerCase()
+						.includes(searchTerm.toLowerCase()) &&
+					(!createdStartDate ||
+						(createdDate && createdDate >= createdStartDate)) &&
+					(!createdEndDate ||
+						(createdDate && createdDate <= createdEndDate)) &&
+					(!dueStartDate || (dueDate && dueDate >= dueStartDate)) &&
+					(!dueEndDate || (dueDate && dueDate <= dueEndDate))
+				);
+			})
+			.sort((a, b) => {
+				const aDate = a.createdDate ? new Date(a.createdDate) : null;
+				const bDate = b.createdDate ? new Date(b.createdDate) : null;
+				return bDate && aDate && bDate > aDate ? 1 : -1;
+			});
 	});
 </script>
 
@@ -37,6 +97,60 @@
 		<Button classes="w-50 ml-2" onclick={() => (addNoteModal = true)}
 			>Add Note</Button
 		>
+	</div>
+	<div class="flex justify-between">
+		<MiniButton classes="flex" color="blue" onclick={clearFilters}
+			><FunnelX />Clear Filters</MiniButton
+		>
+		{#if showMoreFilters}
+			<div class="flex justify-between">
+				<div class="mx-1">
+					<label for="filterCreatedStartDate" class="text-left block"
+						>Due From Date:</label
+					>
+					<input
+						bind:value={filterDueStartDate}
+						type="date"
+						id="filterCreatedStartDate"
+						class="rounded-lg border border-gray-300 bg-gray-800 text-gray-100 focus:border-transparent focus:ring-2 focus:ring-blue-500 focus:outline-none"
+					/>
+				</div>
+				<div class="mx-1">
+					<label for="filterCreatedEndDate" class="text-left block"
+						>To Date:</label
+					>
+					<input
+						bind:value={filterDueEndDate}
+						type="date"
+						id="filterCreatedEndDate"
+						class="rounded-lg border border-gray-300 bg-gray-800 text-gray-100 focus:border-transparent focus:ring-2 focus:ring-blue-500 focus:outline-none"
+					/>
+				</div>
+
+				<div class="mx-1">
+					<label for="filterCreatedStartDate" class="text-left block"
+						>Created From Date:</label
+					>
+					<input
+						bind:value={filterCreatedStartDate}
+						type="date"
+						id="filterCreatedStartDate"
+						class="rounded-lg border border-gray-300 bg-gray-800 text-gray-100 focus:border-transparent focus:ring-2 focus:ring-blue-500 focus:outline-none"
+					/>
+				</div>
+				<div class="mx-1">
+					<label for="filterCreatedEndDate" class="text-left block"
+						>To Date:</label
+					>
+					<input
+						bind:value={filterCreatedEndDate}
+						type="date"
+						id="filterCreatedEndDate"
+						class="rounded-lg border border-gray-300 bg-gray-800 text-gray-100 focus:border-transparent focus:ring-2 focus:ring-blue-500 focus:outline-none"
+					/>
+				</div>
+			</div>
+		{/if}
 	</div>
 	<NotecardTable notes={displayedNotes}></NotecardTable>
 </div>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -3,16 +3,16 @@ import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	// Consult https://svelte.dev/docs/kit/integrations
-	// for more information about preprocessors
-	preprocess: vitePreprocess(),
+    // Consult https://svelte.dev/docs/kit/integrations
+    // for more information about preprocessors
+    preprocess: vitePreprocess(),
 
-	kit: {
-		// adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
-		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
-		// See https://svelte.dev/docs/kit/adapters for more information about adapters.
-		adapter: adapter()
-	}
+    kit: {
+        // adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
+        // If your environment is not supported, or you settled on a specific environment, switch out the adapter.
+        // See https://svelte.dev/docs/kit/adapters for more information about adapters.
+        adapter: adapter()
+    }
 };
 
 export default config;


### PR DESCRIPTION
### Dates
- Created dates are automatically set when a record is added
  - We don't update them on edit, but we could decide later to do so and treat this as a last edit field (we could just make a different field for last edit though)
- Due dates are undefined unless explicitly set by the user (we couldadd a label and info tooltip for this). these can be changed

### Filtering
- Filter on dates - search from low date to high date for both created date and due date

### Fix layout
Previously, notecards would influence the height of their neighbors. Probably undesirable. Now each notecard's height is independant. 
- Improvements we could make: Make it so that notecards are always x units away from each other vertically. As of now there is something goofy going on where the tallest notecard decides how tall a row is. 

Additionally, if note content is too long, we now truncate and make clickable to expand

### Enable editing
Pencil icon on notes opens edit modal