### PR TITLE
Hotfix mini button color

### DIFF
--- a/src/lib/components/MiniButton.svelte
+++ b/src/lib/components/MiniButton.svelte
@@ -17,7 +17,11 @@
     class="{classes} cursor-pointer rounded items-center
     text-center font-bold hover:text-white focus:border-transparent focus:ring-2 focus:ring-white focus:outline-none
     transition duration-100 bg-transparent
-    text-{color}-500
+    {color == 'red'
+        ? 'text-red-500'
+        : color == 'blue'
+          ? 'text-blue-500'
+          : 'text-white'}
     p-2
     "
     >{@render children()}


### PR DESCRIPTION
There's an interaction between svelte and tailwind that causes the way we decide a component's color to mostly not work - instead, we use the more verbose ternary operator to decide color.