### PR TITLE
Pre presentation hotfixes

### DIFF
--- a/src/lib/components/AddOrUpdateNote.svelte
+++ b/src/lib/components/AddOrUpdateNote.svelte
@@ -1,14 +1,12 @@
 <script lang="ts">
 	import TextInput from "./TextInput.svelte";
 	import Button from "./Button.svelte";
-	import { Plus } from "lucide-svelte";
-	import type { Note, Tag, noteTagRelation } from "$lib/db";
+	import type { Note } from "$lib/db";
 	import { addOrUpdateNote } from "$lib/dbDal";
 	import Modal from "./Modal.svelte";
 	import TipTap from "./TipTap.svelte";
 	import { Editor } from "@tiptap/core";
 	import { db } from "$lib/db"; // Import the database instance
-	import MiniButton from "./MiniButton.svelte";
 	import TagList from "./TagList.svelte";
 
 	const DEFAULT_NOTE: Note = {
@@ -57,7 +55,6 @@
 				.anyOf(tagIds)
 				.toArray();
 			tags = existingTags.map((tag) => tag.name); // Populate tags with tag names
-			
 		}
 	}
 
@@ -124,23 +121,10 @@
 			tags = [];
 		}
 	}
-
-	function handleTagInput(index: number, value: string) {
-		tags[index] = value;
-
-		// Add a new input field only if the last one is being edited and not empty
-		if (
-			index === tags.length - 1 &&
-			value.trim() !== "" &&
-			!tags.includes("")
-		) {
-			tags = [...tags]; 
-		}
-	}
 </script>
 
 <Modal size="md" title={note.id ? "Edit Note" : "New Note"} bind:open>
-	<TextInput label="Title" bind:value={note.title} autofocus />
+	<TextInput label="Title" bind:value={note.title} />
 	<TipTap content={note.content ?? ""} bind:editor />
 
 	{#if errorMessage}
@@ -150,10 +134,7 @@
 	<div class="mt-4 flex justify-between">
 		<div>
 			<h3 class="text-lg font-bold mb-2 text-left">Tags</h3>
-			<div class="flex flex-wrap gap-2">
-
-				<TagList bind:tags></TagList>
-			</div>
+			<TagList bind:tags></TagList>
 		</div>
 		<div>
 			<div>

--- a/src/lib/components/AddOrUpdateNote.svelte
+++ b/src/lib/components/AddOrUpdateNote.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
 	import TextInput from "./TextInput.svelte";
 	import Button from "./Button.svelte";
+	import { Plus } from "lucide-svelte";
 	import type { Note, Tag, noteTagRelation } from "$lib/db";
 	import { addOrUpdateNote } from "$lib/dbDal";
 	import Modal from "./Modal.svelte";
 	import TipTap from "./TipTap.svelte";
 	import { Editor } from "@tiptap/core";
 	import { db } from "$lib/db"; // Import the database instance
+	import MiniButton from "./MiniButton.svelte";
+	import TagList from "./TagList.svelte";
 
 	const DEFAULT_NOTE: Note = {
 		title: "",
@@ -30,7 +33,7 @@
 	let success = $state(false);
 	let errorMessage = $state<string>("");
 	let editor = $state<Editor>();
-	let tags = $state<string[]>([""]); // Initialize with one empty input
+	let tags = $state<string[]>([]); // Initialize with one empty input
 
 	// Fetch tags when the modal is opened
 	$effect(() => {
@@ -54,7 +57,7 @@
 				.anyOf(tagIds)
 				.toArray();
 			tags = existingTags.map((tag) => tag.name); // Populate tags with tag names
-			tags = [...tags, ""]; // Add an empty input for new tags
+			
 		}
 	}
 
@@ -118,7 +121,7 @@
 			// Reset the form
 			open = false;
 			note = { ...DEFAULT_NOTE };
-			tags = [""];
+			tags = [];
 		}
 	}
 
@@ -131,7 +134,7 @@
 			value.trim() !== "" &&
 			!tags.includes("")
 		) {
-			tags = [...tags, ""]; // Add a new empty tag input
+			tags = [...tags]; 
 		}
 	}
 </script>
@@ -148,21 +151,8 @@
 		<div>
 			<h3 class="text-lg font-bold mb-2 text-left">Tags</h3>
 			<div class="flex flex-wrap gap-2">
-				{#each tags as tag, index (index)}
-					<!-- Use `index` as the key -->
-					<div class="mb-2">
-						<input
-							type="text"
-							bind:value={tags[index]}
-							oninput={(e) =>
-								handleTagInput(index, e.currentTarget.value)}
-							placeholder="Enter a tag"
-							class="rounded-lg border border-gray-300 bg-gray-800 text-gray-100 focus:border-transparent focus:ring-2 focus:ring-blue-500 focus:outline-none"
-							style="width: auto; min-width: 50px; padding: 4px;"
-							size={tags[index]?.length || 1}
-						/>
-					</div>
-				{/each}
+
+				<TagList bind:tags></TagList>
 			</div>
 		</div>
 		<div>

--- a/src/lib/components/AddOrUpdateNote.svelte
+++ b/src/lib/components/AddOrUpdateNote.svelte
@@ -125,7 +125,7 @@
 </script>
 
 <Modal size="md" title={note.id ? "Edit Note" : "New Note"} bind:open>
-	<TextInput label="Title" bind:value={note.title} />
+	<TextInput label="Title" bind:value={note.title} stealFocus/>
 	<TipTap content={note.content ?? ""} bind:editor />
 
 	{#if errorMessage}

--- a/src/lib/components/AddOrUpdateNote.svelte
+++ b/src/lib/components/AddOrUpdateNote.svelte
@@ -22,7 +22,7 @@
 	};
 
 	let {
-		onupdate,
+		onupdate = () => {},
 		open = $bindable(false),
 		note: _note = { ...DEFAULT_NOTE },
 	}: NoteProps = $props();
@@ -120,6 +120,7 @@
 			note = { ...DEFAULT_NOTE };
 			tags = [];
 		}
+		onupdate(newNote);
 	}
 </script>
 

--- a/src/lib/components/MiniButton.svelte
+++ b/src/lib/components/MiniButton.svelte
@@ -4,25 +4,30 @@
         color = "blue",
         classes = "",
         children,
-    } = $props<{ 
-        onclick?: (e: MouseEvent) => void; 
+        disabled = false,
+    } = $props<{
+        onclick?: (e: MouseEvent) => void;
         color?: "blue" | "red" | "white";
         classes?: string;
         children?: any;
+        disabled?: boolean;
     }>();
 </script>
 
 <button
+    {disabled}
+    type="button"
     {onclick}
     class="{classes} cursor-pointer rounded items-center
     text-center font-bold hover:text-white focus:border-transparent focus:ring-2 focus:ring-white focus:outline-none
     transition duration-100 bg-transparent
-    {color == 'red'
-        ? 'text-red-500'
-        : color == 'blue'
-          ? 'text-blue-500'
-          : 'text-white'}
-    p-2
+    {disabled
+        ? 'text-gray-600'
+        : color == 'red'
+          ? 'text-red-500'
+          : color == 'blue'
+            ? 'text-blue-500'
+            : 'text-white'}
     "
     >{@render children()}
 </button>

--- a/src/lib/components/NoteCard.svelte
+++ b/src/lib/components/NoteCard.svelte
@@ -8,6 +8,7 @@
 	import { db } from "$lib/db";
 	import { onMount } from "svelte";
 	import TagList from "./TagList.svelte";
+	import ViewNote from "./ViewNote.svelte";
 
 	let { note = $bindable(), id = $bindable(0) } = $props<{
 		note: Note;
@@ -53,7 +54,8 @@
 		}
 	});
 
-	let editMode = $state(false);
+	let openEditModal = $state(false);
+	let openViewModal = $state(false);
 	let tags = $state<string[]>([]);
 
 	onMount(async () => {
@@ -68,7 +70,19 @@
 
 <div
 	id="container{id}"
-	class="rounded bg-gray-600 shadow-md max-h-full flex flex-col w-full"
+	class="rounded bg-gray-600 shadow-md max-h-full flex flex-col w-full hover:ring-2 hover:ring-white cursor-pointer"
+	onclick={(e: MouseEvent) => {
+		e.stopPropagation();
+		openViewModal = !openViewModal;
+	}}
+	role="button"
+	tabindex="0"
+	style="z-index: -1;"
+	onkeydown={(e: KeyboardEvent) => {
+		if (e.key === "Enter") {
+			openViewModal = true;
+		}
+	}}
 >
 	<div id="header" class="p-4">
 		<div class="flex justify-between">
@@ -80,8 +94,12 @@
 			>
 				{note?.title ?? "No title available"}
 			</button>
-			<MiniButton color={"red"} onclick={handleDeleteClick}
-				><Trash2 /></MiniButton
+			<MiniButton
+				color={"red"}
+				onclick={(event) => {
+					event.stopPropagation();
+					handleDeleteClick();
+				}}><Trash2 /></MiniButton
 			>
 		</div>
 		<div class="flex text-left justify-between pt-3">
@@ -105,7 +123,7 @@
 		<MiniButton
 			onclick={(e: MouseEvent) => {
 				e.stopPropagation();
-				editMode = !editMode;
+				openEditModal = true;
 			}}><Pencil /></MiniButton
 		>
 	</div>
@@ -113,6 +131,8 @@
 
 <AddOrUpdateNote
 	{note}
-	bind:open={editMode}
+	bind:open={openEditModal}
 	onupdate={(_note) => (note = _note)}
 ></AddOrUpdateNote>
+
+<ViewNote bind:open={openViewModal} {note} {tags} />

--- a/src/lib/components/NoteCard.svelte
+++ b/src/lib/components/NoteCard.svelte
@@ -3,10 +3,12 @@
 	import MiniButton from "./MiniButton.svelte";
 	import AddOrUpdateNote from "./AddOrUpdateNote.svelte";
 	import { deleteNote, getTagsForNote } from "$lib/dbDal";
-	import { Trash2, Pencil } from "lucide-svelte"; 
-	import TipTap from "./TipTap.svelte"; 
-	import { db } from "$lib/db"; 
+	import { Trash2, Pencil } from "lucide-svelte";
+	import TipTap from "./TipTap.svelte";
+	import { db } from "$lib/db";
 	import type { Tag } from "$lib/db";
+	import { onMount } from "svelte";
+	import TagList from "./TagList.svelte";
 
 	let { note = $bindable(), id = $bindable(0) } = $props<{
 		note: Note;
@@ -30,7 +32,6 @@
 		} else {
 			alert("Failed to delete note");
 		}
-
 	};
 	$effect(() => {
 		if (note?.dueDate) {
@@ -55,18 +56,15 @@
 	});
 
 	let editMode = $state(false);
-	let tags = $state<Tag[]>([]);
+	let tags = $state<string[]>([]);
 
-	async function getTags() {
+	onMount(async () => {
 		if (note?.id) {
-			tags = await getTagsForNote(note.id);
-		} else {
-			tags = [];
+			tags = (await getTagsForNote(note.id)).reduce((acc, tag) => {
+				acc.push(tag.name);
+				return acc;
+			}, [] as string[]);
 		}
-	}
-
-	$effect(() => {
-		getTags();
 	});
 </script>
 
@@ -108,11 +106,7 @@
 	/>
 	<div id="footer" class="flex justify-between p-4 h-20">
 		<div id="tags" class="flex">
-			{#each tags as tag}
-				<p class="mr-2 bg-gray-700 rounded px-2 py-1 text-sm h-[2em]">
-					{tag.name}
-				</p>
-			{/each}
+			<TagList bind:tags editable={false}></TagList>
 		</div>
 		<MiniButton
 			onclick={(e: MouseEvent) => {

--- a/src/lib/components/NoteCard.svelte
+++ b/src/lib/components/NoteCard.svelte
@@ -3,10 +3,9 @@
 	import MiniButton from "./MiniButton.svelte";
 	import AddOrUpdateNote from "./AddOrUpdateNote.svelte";
 	import { deleteNote, getTagsForNote } from "$lib/dbDal";
-	import { Trash2, Pencil } from "lucide-svelte";
+	import { Trash2, Pencil, Eye } from "lucide-svelte";
 	import TipTap from "./TipTap.svelte";
 	import { db } from "$lib/db";
-	import type { Tag } from "$lib/db";
 	import { onMount } from "svelte";
 	import TagList from "./TagList.svelte";
 
@@ -16,7 +15,6 @@
 	}>();
 
 	let expandTitle = $state(false);
-	let expandContent = $state(false);
 
 	let dueDateString = $state("");
 	let createdDateString = $state("");
@@ -70,7 +68,7 @@
 
 <div
 	id="container{id}"
-	class="rounded bg-gray-600 shadow-md h-full flex flex-col w-full"
+	class="rounded bg-gray-600 shadow-md max-h-full flex flex-col w-full"
 >
 	<div id="header" class="p-4">
 		<div class="flex justify-between">
@@ -98,13 +96,9 @@
 	<TipTap
 		content={note.content}
 		editable={false}
-		class="
-			note-content
-			bg-gray-500 text-left w-full shrink h-full overflow-hidden
-			{expandContent ? 'break-all' : 'overflow-hidden line-clamp-5'}
-		"
+		class="note-content bg-gray-500 text-left w-full overflow-hidden"
 	/>
-	<div id="footer" class="flex justify-between p-4 h-20">
+	<div id="footer" class="flex justify-between p-4">
 		<div id="tags" class="flex">
 			<TagList bind:tags editable={false}></TagList>
 		</div>

--- a/src/lib/components/NotecardTable.svelte
+++ b/src/lib/components/NotecardTable.svelte
@@ -2,16 +2,15 @@
     import { type Note } from "$lib/db";
     import Notecard from "./NoteCard.svelte";
 
-    export let notes: Note[] = [];
+    let { notes = $bindable() } = $props<{ notes: Note[] }>();
 </script>
 
 <div class="flex flex-col lg:flex-row lg:flex-wrap md:flex-row md:flex-wrap">
     {#each notes as note, index (note)}
         <div
-            class="lg:w-1/3 sm:w-full md:w-1/2 p-4 h-[30rem] overflow-hidden"
-            style=""
+            class="lg:w-1/3 sm:w-full md:w-1/2 p-4 max-h-[40rem] overflow-hidden"
         >
-            <Notecard bind:note id={index}></Notecard>
+            <Notecard bind:note={notes[index]} id={index}></Notecard>
         </div>
     {/each}
 </div>

--- a/src/lib/components/TagInput.svelte
+++ b/src/lib/components/TagInput.svelte
@@ -1,21 +1,42 @@
 <script lang="ts">
-    let { tag = $bindable(""), editable = true } = $props<{
+    import { onMount } from "svelte";
+
+    let { tag = $bindable(""), editable = $bindable(true) } = $props<{
         tag: string;
         editable?: boolean;
     }>();
+
+    let inputEl: HTMLInputElement;
+
+    onMount(() => {
+        if (editable && inputEl) {
+            inputEl.focus();
+        }
+    });
+
+    function normalizeInput(event: Event) {
+        const target = event.target as HTMLInputElement;
+        tag = target.value.toLowerCase().replace(/\s+/g, "-");
+    }
 </script>
 
-<button onclick={() => (editable = true)}>
-    {#if editable}
+{#if editable}
+    <span>
         <input
-            bind:value={tag}
+            bind:this={inputEl}
+            value={tag}
+            oninput={normalizeInput}
             type="text"
-            class="rounded-lg border border-gray-300 bg-gray-800 text-gray-100 focus:border-transparent focus:ring-2 focus:ring-blue-500 focus:outline-none"
+            class="w-25 m-1 p-2 rounded-lg border border-gray-300 bg-gray-800 text-gray-100 focus:border-transparent focus:ring-2 focus:ring-blue-500 focus:outline-none"
             maxlength={30}
-            onblur={() => (editable = false)}
-            
         />
-    {:else}
-        <span class="p-2 bg-gray-800 text-gray-100">{tag}</span>
-    {/if}
-</button>
+    </span>
+{:else}
+    <span
+        class="rounded bg-gray-700 text-gray-100 flex justify-between items-center pl-1 pr-1 m-1"
+    >
+        <span class="m-1">
+            {tag}
+        </span>
+    </span>
+{/if}

--- a/src/lib/components/TagInput.svelte
+++ b/src/lib/components/TagInput.svelte
@@ -33,10 +33,8 @@
     </span>
 {:else}
     <span
-        class="rounded bg-gray-700 text-gray-100 flex justify-between items-center pl-1 pr-1 m-1"
+        class="m-1 p-1 max-w-25 rounded bg-gray-700 text-gray-100 flex justify-between items-center overflow-hidden  whitespace-nowrap truncate"
     >
-        <span class="m-1">
-            {tag}
-        </span>
+        {tag}
     </span>
 {/if}

--- a/src/lib/components/TagInput.svelte
+++ b/src/lib/components/TagInput.svelte
@@ -14,6 +14,10 @@
         }
     });
 
+    function getTagLink(tagName: string): string {
+        return `/?search=%23${encodeURIComponent(tagName)}`;
+    }
+
     function normalizeInput(event: Event) {
         const target = event.target as HTMLInputElement;
         tag = target.value.toLowerCase().replace(/\s+/g, "-");
@@ -32,9 +36,14 @@
         />
     </span>
 {:else}
-    <span
-        class="m-1 p-1 max-w-25 rounded bg-gray-700 text-gray-100 flex justify-between items-center overflow-hidden  whitespace-nowrap truncate"
+    <a
+        style="z-index: 1;"
+        onclick={(event) => {
+            event.stopPropagation();
+        }}
+        class="hover:ring-white hover:ring-2 m-1 p-2 max-w-25 rounded bg-gray-800 text-gray-200 flex justify-between items-center overflow-hidden whitespace-nowrap truncate"
+        href={getTagLink(tag)}
     >
         {tag}
-    </span>
+    </a>
 {/if}

--- a/src/lib/components/TagInput.svelte
+++ b/src/lib/components/TagInput.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+    let { tag = $bindable(""), editable = true } = $props<{
+        tag: string;
+        editable?: boolean;
+    }>();
+</script>
+
+<button onclick={() => (editable = true)}>
+    {#if editable}
+        <input
+            bind:value={tag}
+            type="text"
+            class="rounded-lg border border-gray-300 bg-gray-800 text-gray-100 focus:border-transparent focus:ring-2 focus:ring-blue-500 focus:outline-none"
+            maxlength={30}
+            onblur={() => (editable = false)}
+            
+        />
+    {:else}
+        <span class="p-2 bg-gray-800 text-gray-100">{tag}</span>
+    {/if}
+</button>

--- a/src/lib/components/TagInput.svelte
+++ b/src/lib/components/TagInput.svelte
@@ -41,7 +41,7 @@
         onclick={(event) => {
             event.stopPropagation();
         }}
-        class="hover:ring-white hover:ring-2 m-1 p-2 max-w-25 rounded bg-gray-800 text-gray-200 flex justify-between items-center overflow-hidden whitespace-nowrap truncate"
+        class="hover:ring-white hover:ring-2 m-1 p-2 rounded bg-gray-800 text-gray-200 flex justify-between items-center overflow-hidden whitespace-nowrap truncate"
         href={getTagLink(tag)}
     >
         {tag}

--- a/src/lib/components/TagList.svelte
+++ b/src/lib/components/TagList.svelte
@@ -9,14 +9,18 @@
     }>();
 </script>
 
-<div class="flex justify-between">
-    <MiniButton
-        color="blue"
-        onclick={() => {
-            tags = ["", ...tags];
-        }}><Plus /></MiniButton
-    >
+<div id="tag-container" class="flex flex-wrap gap-2 items-center">
+    {#if editable}
+        <MiniButton
+            classes={tags.length > 4 ? "hidden" : ""}
+            disabled={(tags[0]?.length ?? 1) == 0}
+            color="blue"
+            onclick={() => {
+                tags = ["", ...tags];
+            }}><Plus /></MiniButton
+        >
+    {/if}
     {#each tags as element, i}
-        <TagInput bind:tag={tags[i]}></TagInput>
+        <TagInput bind:editable bind:tag={tags[i]}></TagInput>
     {/each}
 </div>

--- a/src/lib/components/TagList.svelte
+++ b/src/lib/components/TagList.svelte
@@ -9,7 +9,7 @@
     }>();
 </script>
 
-<div id="tag-container" class="flex flex-wrap gap-2 items-center">
+<div id="tag-container" class="flex flex-wrap items-center">
     {#if editable}
         <MiniButton
             classes={tags.length > 4 ? "hidden" : ""}

--- a/src/lib/components/TagList.svelte
+++ b/src/lib/components/TagList.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+    import MiniButton from "./MiniButton.svelte";
+    import { Plus } from "lucide-svelte";
+    import TagInput from "./TagInput.svelte";
+
+    let { tags = $bindable([]), editable = true } = $props<{
+        tags: string[];
+        editable?: boolean;
+    }>();
+</script>
+
+<div class="flex justify-between">
+    <MiniButton
+        color="blue"
+        onclick={() => {
+            tags = ["", ...tags];
+        }}><Plus /></MiniButton
+    >
+    {#each tags as element, i}
+        <TagInput bind:tag={tags[i]}></TagInput>
+    {/each}
+</div>

--- a/src/lib/components/TagList.svelte
+++ b/src/lib/components/TagList.svelte
@@ -21,6 +21,6 @@
         >
     {/if}
     {#each tags as element, i}
-        <TagInput bind:editable bind:tag={tags[i]}></TagInput>
+        <TagInput {editable} bind:tag={tags[i]}></TagInput>
     {/each}
 </div>

--- a/src/lib/components/TextInput.svelte
+++ b/src/lib/components/TextInput.svelte
@@ -2,10 +2,10 @@
     export let value = "";
     export let label = "";
     export let type: "text" | "textarea" | "password" = "text";
-
     export let classes = "";
-
+    export let maxlength: number = 5000;
     export let onchange = () => {};
+    export let onblur = () => {};
 
     // Add autofocus as a prop
     export let autofocus: boolean = false;
@@ -19,7 +19,9 @@
             placeholder=" "
             bind:value
             onchange={() => onchange()}
-            {autofocus} 
+            {onblur}
+            {autofocus}
+            {maxlength}
         ></textarea>
         <label
             for={label}
@@ -36,7 +38,9 @@
             placeholder=" "
             bind:value
             onchange={() => onchange()}
+            {onblur}
             id={label}
+            {maxlength}
             {autofocus}
         />
         <label

--- a/src/lib/components/TextInput.svelte
+++ b/src/lib/components/TextInput.svelte
@@ -6,9 +6,6 @@
     export let maxlength: number = 5000;
     export let onchange = () => {};
     export let onblur = () => {};
-
-    // Add autofocus as a prop
-    export let autofocus: boolean = false;
 </script>
 
 {#if type == "textarea"}
@@ -20,7 +17,6 @@
             bind:value
             onchange={() => onchange()}
             {onblur}
-            {autofocus}
             {maxlength}
         ></textarea>
         <label
@@ -41,7 +37,6 @@
             {onblur}
             id={label}
             {maxlength}
-            {autofocus}
         />
         <label
             for={label}

--- a/src/lib/components/TextInput.svelte
+++ b/src/lib/components/TextInput.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { onMount } from "svelte";
     export let value = "";
     export let label = "";
     export let type: "text" | "textarea" | "password" = "text";
@@ -6,6 +7,15 @@
     export let maxlength: number = 5000;
     export let onchange = () => {};
     export let onblur = () => {};
+    export let stealFocus = false;
+
+    let inputEl: HTMLInputElement;
+
+    onMount(() => {
+        if (inputEl && stealFocus) {
+            inputEl.focus();
+        }
+    });
 </script>
 
 {#if type == "textarea"}
@@ -37,6 +47,7 @@
             {onblur}
             id={label}
             {maxlength}
+            bind:this={inputEl}
         />
         <label
             for={label}

--- a/src/lib/components/TipTap.svelte
+++ b/src/lib/components/TipTap.svelte
@@ -63,9 +63,10 @@
 	role="button"
 	tabindex="0"
 	class={`
-		${editable && `peer editable`}
+		min-h-30
+		${editable && `peer editable h-200`}
 
-		note-content overflow-y-auto h-200
+		note-content overflow-y-auto 
 		${
 			editable &&
 			` 
@@ -139,7 +140,9 @@
 
 	.note-content :global(.tiptap) {
 		cursor: text;
-		height: 100%;
+		height: auto; /* not 100% */
+		max-height: 100%;
+		overflow-y: auto;
 	}
 
 	.note-content :global(.tiptap:focus) {

--- a/src/lib/components/TipTap.svelte
+++ b/src/lib/components/TipTap.svelte
@@ -72,7 +72,6 @@
 			` 
 				peer w-full rounded-lg border border-gray-300 bg-gray-800 text-gray-100 
 				focus:border-transparent focus:ring-2 focus:ring-blue-500 focus:outline-none
-				hover:cursor-pointer
 			`
 		}
 		${args.class}
@@ -139,7 +138,6 @@
 	}
 
 	.note-content :global(.tiptap) {
-		cursor: text;
 		height: auto; /* not 100% */
 		max-height: 100%;
 		overflow-y: auto;

--- a/src/lib/components/ViewNote.svelte
+++ b/src/lib/components/ViewNote.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+    import { type Note } from "$lib/db";
+    import Modal from "./Modal.svelte";
+    import TagList from "./TagList.svelte";
+    import TipTap from "./TipTap.svelte";
+
+    let {
+        note,
+        tags = [],
+        open = $bindable(false),
+    } = $props<{ note: Note; tags?: string[]; open: boolean }>();
+</script>
+
+<Modal size="lg" title="View Note" bind:open>
+    <div class="content-center p-4 rounded-lg max-h-200 overflow-auto bg-gray-600">
+        <h2 class="text-xl font-bold mb-2 text-left">{note.title}</h2>
+        <TipTap
+            content={note.content}
+            editable={false}
+            class="note-content rounded-lg text-left overflow-auto w-full overflow-hidden"
+        />
+    </div>
+    <h3 class="text-lg font-bold mt-2 text-left">Tags</h3>
+    <TagList bind:tags editable={false} />
+</Modal>

--- a/src/lib/components/ViewNote.svelte
+++ b/src/lib/components/ViewNote.svelte
@@ -9,17 +9,51 @@
         tags = [],
         open = $bindable(false),
     } = $props<{ note: Note; tags?: string[]; open: boolean }>();
+
+    let dueDateString = $state("");
+    let createdDateString = $state("");
+
+    $effect(() => {
+        if (note?.dueDate) {
+            dueDateString =
+                "Due: " +
+                new Date(note.dueDate).toLocaleDateString("en-US", {
+                    month: "numeric",
+                    day: "numeric",
+                    year: "numeric",
+                });
+        }
+
+        if (note?.createdDate) {
+            createdDateString =
+                "Created: " +
+                note.createdDate.toLocaleDateString("en-US", {
+                    month: "numeric",
+                    day: "numeric",
+                    year: "numeric",
+                });
+        }
+    });
 </script>
 
 <Modal size="lg" title="View Note" bind:open>
-    <div class="content-center p-4 rounded-lg max-h-200 overflow-auto bg-gray-600">
-        <h2 class="text-xl font-bold mb-2 text-left">{note.title}</h2>
+    <div
+        class="content-center p-4 rounded-lg max-h-200 overflow-auto bg-gray-600"
+    >
+    <h2 class="text-xl font-bold mb-2 text-left">{note.title}</h2>
+    <div class="text-left">
+        <p class="text-sm text-gray-200 mb-2">
+            {createdDateString}
+        </p>
+        <p class="text-sm text-gray-200 mb-2">
+            {dueDateString}
+        </p>
+    </div>
         <TipTap
             content={note.content}
             editable={false}
             class="note-content rounded-lg text-left overflow-auto w-full overflow-hidden"
         />
     </div>
-    <h3 class="text-lg font-bold mt-2 text-left">Tags</h3>
     <TagList bind:tags editable={false} />
 </Modal>

--- a/src/lib/utils/HotKeys.svelte
+++ b/src/lib/utils/HotKeys.svelte
@@ -15,6 +15,11 @@
       const el = document.querySelector('.New-Note-Button') as HTMLElement;
       el?.click();
     }
+    if (event.altKey && event.key == "Backspace") {
+      event.preventDefault();
+      const el = document.querySelector('.Clear-Filters-Button') as HTMLElement;
+      el?.click();
+    }
     //other hotkeys here
     if (event.altKey && event.key === "r") {
       getTags().then((tags: Tag[]) => {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -173,7 +173,7 @@
 		>
 	</div>
 	<div class="hidden sm:flex justify-between">
-		<MiniButton classes="flex" color="blue" onclick={clearFilters}
+		<MiniButton classes="flex Clear-Filters-Button" color="blue" onclick={clearFilters}
 			><FunnelX />Clear Filters</MiniButton
 		>
 		<div class="flex justify-between flex-wrap">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -263,11 +263,8 @@
 
 <AddOrUpdateNote
 	bind:open={openModal}
-	onupdate={(updatedNote: Note) => {
-		// Refresh the tags for the updated note
-		_notes = _notes.map((note) =>
-			note.id === updatedNote.id ? updatedNote : note,
-		);
+	onupdate={async () => {
+		await updateNotes();
 	}}
 ></AddOrUpdateNote>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,7 +15,7 @@
 
 	let _notes: Note[] = $state([]);
 	import { addOrUpdateNote } from "$lib/dbDal";
-    import { on } from "svelte/events";
+	import { on } from "svelte/events";
 
 	let openModal: boolean = $state(false);
 	let searchTerm = $state("");
@@ -58,8 +58,7 @@
 					.map((tag) => tag?.id) // Extract `id`
 					.filter((id): id is number => id !== undefined); // Remove `undefined`
 			})();
-		}
-		else {
+		} else {
 			searchTerm = "";
 			TitleSearchTerm = "";
 			searchTagIds = [];
@@ -80,6 +79,7 @@
 		}
 	});
 	let arrangeDisplayedNotes = $derived(async () => {
+		if (!$dbNotes) return [];
 		const notes = await Promise.all(
 			$dbNotes.map(async (note) => {
 				if (!note.title) return null;
@@ -108,30 +108,31 @@
 				if (dueEndDate) dueEndDate.setHours(23, 59, 59, 999);
 
 				// Fetch tags for the note
-				console.log("Note ID:", note.id);
 				const tags = await getTagsForNote(note.id as number);
-				console.log("Tags fetched for note:", note.id, tags);
-
 				// Ensure tags is an array before mapping
 				const noteTagIds = (tags || []).map((tag) => tag.id as number);
-				console.log("Note Tag IDs:", noteTagIds);
-
 				// Access the value of searchTagIds if it's a store
 				// idk why this makes the errors go away but it does :D
-				const resolvedSearchTagIds = Array.isArray(searchTagIds) ? searchTagIds : searchTagIds as number[];
-				console.log("Search Tag IDs:", resolvedSearchTagIds);
+				const resolvedSearchTagIds = Array.isArray(searchTagIds)
+					? searchTagIds
+					: (searchTagIds as number[]);
 
 				// Check if tags match
 				const matchesTag =
-				  resolvedSearchTagIds.length === 0 ||
-				  resolvedSearchTagIds.every((tagId) => noteTagIds.includes(tagId));
-				console.log("Matches Tag:", matchesTag);
+					resolvedSearchTagIds.length === 0 ||
+					resolvedSearchTagIds.every((tagId) =>
+						noteTagIds.includes(tagId),
+					);
 
 				// Return the note if it matches all conditions
 				if (
-					note.title.toLowerCase().includes(TitleSearchTerm.toLowerCase()) &&
-					(!createdStartDate || (createdDate && createdDate >= createdStartDate)) &&
-					(!createdEndDate || (createdDate && createdDate <= createdEndDate)) &&
+					note.title
+						.toLowerCase()
+						.includes(TitleSearchTerm.toLowerCase()) &&
+					(!createdStartDate ||
+						(createdDate && createdDate >= createdStartDate)) &&
+					(!createdEndDate ||
+						(createdDate && createdDate <= createdEndDate)) &&
 					(!dueStartDate || (dueDate && dueDate >= dueStartDate)) &&
 					(!dueEndDate || (dueDate && dueDate <= dueEndDate)) &&
 					matchesTag
@@ -261,13 +262,13 @@
 </div>
 
 <AddOrUpdateNote
-    bind:open={openModal}
-    onupdate={(updatedNote: Note) => {
-        // Refresh the tags for the updated note
-        _notes = _notes.map((note) =>
-            note.id === updatedNote.id ? updatedNote : note
-        );
-    }}
+	bind:open={openModal}
+	onupdate={(updatedNote: Note) => {
+		// Refresh the tags for the updated note
+		_notes = _notes.map((note) =>
+			note.id === updatedNote.id ? updatedNote : note,
+		);
+	}}
 ></AddOrUpdateNote>
 
 <HotKeys />

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -1,25 +1,37 @@
 <div class="px-6 py-4">
     <h1 class="text-xl font-bold text-center mb-6">About QuickNote</h1>
     <div class="text-left pl-6 max-w-full">
-      <p class="text-lg leading-relaxed">
-        QuickNote was developed to address the everyday need for an efficient and organized way to manage various types of information, 
-        such as tasks, class notes, phone numbers, recipes, and any other important data you wish to keep for future reference. 
-        With the fast-paced nature of life, we recognized the importance of having a reliable tool that allows users to quickly record fleeting thoughts, 
-        reminders, or ideas. Our mission was to design an app that not only offers a seamless note-taking experience but also allows users to 
-        retrieve information with ease, ensuring that their notes are always accessible when needed most.
-        <br /><br />
-        By focusing on an intuitive and user-friendly interface, QuickNote aims to provide a simple yet powerful solution for managing 
-        personal and professional information. The goal is for users to effortlessly capture and organize their thoughts, 
-        ensuring that every piece of valuable information is at their fingertips, anytime and anywhere.
-        <br /><br />
-        Tags optimize the organization of your notes, simplifying the process of finding content associated with specific topics. 
-        This feature ensures fast and effective searching, allowing users to swiftly access relevant information.
-        <br /><br />
+        <p class="text-lg leading-relaxed">
+            QuickNote was developed to address the everyday need for an
+            efficient and organized way to manage various types of information,
+            such as tasks, class notes, phone numbers, recipes, and any other
+            important data you wish to keep for future reference. With the
+            fast-paced nature of life, we recognized the importance of having a
+            reliable tool that allows users to quickly record fleeting thoughts,
+            reminders, or ideas. Our mission was to design an app that not only
+            offers a seamless note-taking experience but also allows users to
+            retrieve information with ease, ensuring that their notes are always
+            accessible when needed most.
+            <br /><br />
+            By focusing on an intuitive and user-friendly interface, QuickNote aims
+            to provide a simple yet powerful solution for managing personal and professional
+            information. The goal is for users to effortlessly capture and organize
+            their thoughts, ensuring that every piece of valuable information is
+            at their fingertips, anytime and anywhere.
+            <br /><br />
+            Tags optimize the organization of your notes, simplifying the process
+            of finding content associated with specific topics. This feature ensures
+            fast and effective searching, allowing users to swiftly access relevant
+            information.
+            <br /><br />
+        </p>
         <h2 class="text-xl font-bold underline">Shortcuts</h2>
         <ul class="list-disc pl-8 max-w-full">
             <strong>Alt + N: </strong> Create a new note.
             <br /><br />
             <strong>Alt + E: </strong> Focus the cursor on the search bar.
+            <br /><br />
+            <strong>Alt + Backspace: </strong> Clear filters.
         </ul>
     </div>
 </div>

--- a/src/routes/tags/+page.svelte
+++ b/src/routes/tags/+page.svelte
@@ -1,13 +1,19 @@
 <script lang="ts">
+  import TagList from "$lib/components/TagList.svelte";
   import { db } from "$lib/db"; // Import the database instance
   import type { Tag } from "$lib/db";
   import { onMount } from "svelte";
 
-  let tags: Tag[] = []; // Array to store all tags
+  let tags: string[] = []; // Array to store all tags
 
   // Fetch all tags from the database when the component is mounted
   onMount(async () => {
-    tags = await db.tags.toArray();
+    tags = (await db.tags.toArray()).reduce((acc: string[], tag: Tag) => {
+      if (tag.name && !acc.includes(tag.name)) {
+        acc.push(tag.name); // Add unique tag names to the array
+      }
+      return acc;
+    }, []);
   });
 
   // Generate the URL for the home page with the tag in the search bar
@@ -16,18 +22,6 @@
   }
 </script>
 
-<div class="p-4">
-  <h1 class="text-2xl font-bold mb-4">Tags</h1>
-  <ul class="list-disc pl-5">
-    {#each tags as tag}
-      <li>
-        <a
-          href={getTagLink(tag.name)}
-          class="text-blue-500 hover:underline"
-        >
-          #{tag.name}
-        </a>
-      </li>
-    {/each}
-  </ul>
+<div id="tags" class="flex">
+  <TagList {tags} editable={false}></TagList>
 </div>


### PR DESCRIPTION
1. Tag list improvements: componentized tag display, each tag is clickable (puts the tag text into the filter search bar), use plus button to add another tag input, use new tag components in routes/tags
2. add view only modal for notecards
3. improvements to main page layout: height of notecards is no longer dependent on the tallest notecard in the row, now just shrinks if it can. (todo: make it so that the top of a note is a fixed distance from the bottom of a note above it)
4. alt+backspace hotkey clears filters
5. get rid of unnecessary logs, including one that came from errors from svelte trying to evaluate an empty array of notes